### PR TITLE
feat: Implement a customizable standard array for D&D 5e ability scores

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -140,6 +140,10 @@
           "Name": "Allow standard array",
           "Hint": "Allow the user to use the standard array"
         },
+        "StandardArray": {
+          "Name": "Custom standard array",
+          "Hint": "Set the custom standard array values (comma separated, e.g. 15, 14, 13, 12, 10, 8)"
+        },
         "AllowPointBuy": {
           "Name": "Allow point buy",
           "Hint": "Allow the user to use the point buy system",
@@ -449,7 +453,7 @@
       "Skip": "Skip",
       "Retry": "Retry",
       "SelectedSpells": "Selected Spells",
-      "AvailableSpells":"Available Spells",
+      "AvailableSpells": "Available Spells",
       "NoSpellsSelected": "No spells selected"
     },
     "FeatSelector": {
@@ -463,7 +467,7 @@
     },
     "SpellSchool": {
       "abj": "Abjuration",
-      "con": "Conjuration", 
+      "con": "Conjuration",
       "div": "Divination",
       "enc": "Enchantment",
       "evo": "Evocation",

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -79,14 +79,5 @@ export const POINT_BUY_COSTS = {
   15: 9
 }
 
-export const STANDARD_ARRAY = {
-  str: 15, 
-  dex: 14, 
-  con: 13, 
-  int: 12, 
-  wis: 10, 
-  cha: 8
-};
-
 export type CLASS_LEVEL = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
 

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -42,6 +42,7 @@ export function registerSettings(app: Game): void {
   defaultStartingGoldDice();
   allowManualInput();
   allowStandardArray();
+  standardArray();
   allowPointBuy();
   pointBuyLimit();
   allowRolling(app);
@@ -478,6 +479,17 @@ function allowStandardArray() {
     config: true,
     default: false,
     type: Boolean,
+  });
+}
+
+function standardArray() {
+  game.settings.register(MODULE_ID, 'standardArray', {
+    name: game.i18n.localize('GAS.Setting.AbilityEntry.StandardArray.Name'),
+    hint: game.i18n.localize('GAS.Setting.AbilityEntry.StandardArray.Hint'),
+    scope: 'world',
+    config: true,
+    default: '15, 14, 13, 12, 10, 8',
+    type: String,
   });
 }
 


### PR DESCRIPTION
This pull request adds support for customizing the standard ability score array in the DnD5e Ability Entry component. Instead of using a hardcoded array, the standard array values are now configurable via a new game setting. The changes ensure that ability assignment, reset logic, and progress tracking all use the custom values.

**Custom Standard Array Support**

* Added a new game setting `standardArray` that allows users to specify custom standard array values for ability scores. The setting is registered and localized in `src/settings/index.ts` and `lang/en.json`. [[1]](diffhunk://#diff-8b4c1bff9f8027d1d3275147b9e60a7355bf8101b553b7cc08e9147f7745df17R485-R495) [[2]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R143-R146)
* Removed the hardcoded `STANDARD_ARRAY` from `src/helpers/constants.ts` and replaced its usage in `StandardArray.svelte` with a dynamically generated array from the new setting. [[1]](diffhunk://#diff-870703263032cd0d70bc2177a820437086685adf3c00ebee240f83b7758d9561L82-L90) [[2]](diffhunk://#diff-c9f2e024f66d36b50dd88213bd7ecc0e9eef11dfcdb15fd55957263da9a8c0d3L10-R15) [[3]](diffhunk://#diff-c9f2e024f66d36b50dd88213bd7ecc0e9eef11dfcdb15fd55957263da9a8c0d3R24-R42)
* Updated ability assignment and reset logic in `StandardArray.svelte` to use the custom standard array, ensuring that ability values and progress tracking reflect user configuration. [[1]](diffhunk://#diff-c9f2e024f66d36b50dd88213bd7ecc0e9eef11dfcdb15fd55957263da9a8c0d3L69-R91) [[2]](diffhunk://#diff-c9f2e024f66d36b50dd88213bd7ecc0e9eef11dfcdb15fd55957263da9a8c0d3L112-R152)

**Settings Initialization**

* Ensured the new `standardArray` setting is registered during app initialization by updating the settings registration flow in `src/settings/index.ts`.