### PR TITLE
Fix: Equipment selector dropdown clipped when displayed below planned inventory

### DIFF
--- a/src/components/organisms/dnd5e/Tabs/Equipment.svelte
+++ b/src/components/organisms/dnd5e/Tabs/Equipment.svelte
@@ -119,8 +119,8 @@ StandardTabLayout(tabName="equipment")
         )
   div(slot="right")
     +if("!(is2014Rules && userChose2014Gold)")
-      PlannedInventory
       EquipmentSelectorDetail
+      PlannedInventory
 </template>
 
 <style lang="sass">


### PR DESCRIPTION
When selecting "Any Simple Weapon" (or similar flexible weapon options) during character creation, the equipment selector (EquipmentSelectorDetail) was rendered below the Planned Inventory table in the right panel.

I swapped the render order in the right slot so that EquipmentSelectorDetail appears above PlannedInventory
<img width="987" height="966" alt="image" src="https://github.com/user-attachments/assets/8db4c9c9-fa27-4065-af9c-23ca870946e0" />
