### PR TITLE
Handle multiclass error; use Map size check

### DIFF
--- a/src/components/organisms/dnd5e/Tabs/LevelUp.svelte
+++ b/src/components/organisms/dnd5e/Tabs/LevelUp.svelte
@@ -370,7 +370,7 @@ $: if($classUuidForLevelUp) {
  * Filters class advancements for the current level
  * Maps advancement data to include IDs for component rendering
  */
-   $: if ($levelUpClassObject?.system?.advancement.length) {
+   $: if ($levelUpClassObject?.system?.advancement.size) {
     classAdvancementArrayFiltered = $levelUpClassObject?.advancement?.byLevel[newLevel]
   } else {
     classAdvancementArrayFiltered = [];

--- a/src/helpers/Utility.js
+++ b/src/helpers/Utility.js
@@ -237,10 +237,17 @@ export function getLevelByDropType(actor, droppedItem) {
   // window.GAS.log.d('getLevelByDropType', droppedItem);
   // window.GAS.log.d('actor', actor);
   switch (droppedItem.type) {
-    case 'class':
-      return actor.classes[droppedItem.system.identifier].system.levels
-    case 'subclass':
-      return actor.classes[droppedItem.system.classIdentifier].system.levels
+    case 'class': {
+      const actorClass = actor.classes[droppedItem.system.identifier];
+      // New multiclass: the actor doesn't have this class yet, so it starts at level 1
+      if (!actorClass) return 1;
+      return actorClass.system.levels;
+    }
+    case 'subclass': {
+      const actorClass = actor.classes[droppedItem.system.classIdentifier];
+      if (!actorClass) return 1;
+      return actorClass.system.levels;
+    }
     case 'race':
     case 'background':
     default:


### PR DESCRIPTION

<img width="1419" height="726" alt="image" src="https://github.com/user-attachments/assets/d77916ba-6c5c-4b9e-bbc5-44a4f1e821bf" />

1.  Add null checks when resolving an actor's class/subclass during item drops and return 1 when the class isn't present (new multiclass case). This avoids runtime errors when dropping class/subclass items for classes the actor doesn't yet have.

LevelUp.svelte: Use .system?.advancement.size instead of .system?.advancement.length to correctly check for entries (advancement is a Map-like collection).