### PR TITLE
Add trickster identifier for third level spellcasters

### DIFF
--- a/src/components/organisms/dnd5e/Tabs/Spells.svelte
+++ b/src/components/organisms/dnd5e/Tabs/Spells.svelte
@@ -376,7 +376,7 @@
     // Standard D&D 5e spellcasting progression for full casters
     const fullCasters = ['bard', 'cleric', 'druid', 'sorcerer', 'wizard'];
     const halfCasters = ['paladin', 'ranger'];
-    const thirdCasters = ['arcane trickster', 'arcane-trickster', 'eldritch knight', 'eldritch-knight'];
+    const thirdCasters = ['arcane trickster', 'arcane-trickster', 'eldritch knight', 'eldritch-knight', 'trickster'];
     const warlockProgression = ['warlock'];
     
     if (fullCasters.includes(normalizedClassName)) {

--- a/src/helpers/LevelUpStateMachine.js
+++ b/src/helpers/LevelUpStateMachine.js
@@ -268,7 +268,7 @@ function determineSpellListClass(actor) {
       if (identifier === 'eldritch-knight' || identifier === 'eldritchknight') {
         window.GAS.log.d('[LEVELUP] Found Eldritch Knight by identifier -> Wizard');
         return 'Wizard';
-      } else if (identifier === 'arcane-trickster' || identifier === 'arcanetrickster') {
+      } else if (identifier === 'arcane-trickster' || identifier === 'arcanetrickster' || identifier == 'trickster') {
         window.GAS.log.d('[LEVELUP] Found Arcane Trickster by identifier -> Wizard');
         return 'Wizard';
       } else if (identifier === 'aberrant-mind' || identifier === 'aberrantmind') {
@@ -294,9 +294,9 @@ function determineSpellListClass(actor) {
     if (subclass) {
       // Check if this is a known spellcasting subclass
       const subclassLower = subclass.toLowerCase();
-      if (['eldritchknight', 'arcanetrickster', 'aberrantmind'].includes(subclassLower)) {
+      if (['eldritchknight', 'arcanetrickster', 'aberrantmind', 'trickster'].includes(subclassLower)) {
         // These subclasses use specific spell lists
-        if (subclassLower === 'eldritchknight' || subclassLower === 'arcanetrickster') {
+        if (subclassLower === 'eldritchknight' || subclassLower === 'arcanetrickster' || subclassLower == 'trickster') {
           window.GAS.log.d('[LEVELUP] Found subclass in class data:', subclass, '-> Wizard');
           return 'Wizard';
         } else if (subclassLower === 'aberrantmind') {
@@ -620,7 +620,7 @@ export const levelUpFSMContext = {
     // Method 3: Fallback check for known spellcasting classes/subclasses
     const knownSpellcastingClasses = [
       'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard',
-      'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight'
+      'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight', 'trickster'
     ];
     const hasKnownSpellcastingClass = classNamesLower.some(className => 
       knownSpellcastingClasses.includes(className)
@@ -630,13 +630,13 @@ export const levelUpFSMContext = {
     // This is a more aggressive check for cases where the actor system hasn't been updated yet
     const hasSubclassSpellcasting = classNamesLower.some(lowerClassName => {
       // Check for known spellcasting subclasses
-      return ['eldritchknight', 'arcanetrickster', 'aberrantmind'].includes(lowerClassName);
+      return ['eldritchknight', 'arcanetrickster', 'aberrantmind', 'trickster'].includes(lowerClassName);
     });
     
     // Method 5: Check for subclass in the class data itself (e.g., fighter with eldritchknight subclass)
     const hasSubclassInClassData = classDataList.some(classData => {
       const subclass = classData?.system?.subclass;
-      return subclass && ['eldritchknight', 'arcanetrickster', 'aberrantmind'].includes(subclass.toLowerCase());
+      return subclass && ['eldritchknight', 'arcanetrickster', 'aberrantmind', 'trickster'].includes(subclass.toLowerCase());
     });
     
     const isSpellcaster = hasClassSpellcasting || hasActorSpellcasting || hasKnownSpellcastingClass || hasSubclassSpellcasting || hasSubclassInClassData;

--- a/src/helpers/WorkflowStateMachine.js
+++ b/src/helpers/WorkflowStateMachine.js
@@ -209,7 +209,7 @@ export const workflowFSMContext = {
     // Method 3: Fallback check for known spellcasting classes/subclasses
     const knownSpellcastingClasses = [
       'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard',
-      'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight'
+      'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight', 'trickster'
     ];
     const hasKnownSpellcastingClass = classNamesLower.some(className => 
       knownSpellcastingClasses.includes(className)
@@ -219,13 +219,13 @@ export const workflowFSMContext = {
     // This is a more aggressive check for cases where the actor system hasn't been updated yet
     const hasSubclassSpellcasting = classNamesLower.some(lowerClassName => {
       // Check for known spellcasting subclasses
-      return ['eldritchknight', 'arcanetrickster', 'aberrantmind'].includes(lowerClassName);
+      return ['eldritchknight', 'arcanetrickster', 'aberrantmind', 'trickster'].includes(lowerClassName);
     });
     
     // Method 5: Check for subclass in the class data itself (e.g., fighter with eldritchknight subclass)
     const hasSubclassInClassData = classDataList.some(classData => {
       const subclass = classData?.system?.subclass;
-      return subclass && ['eldritchknight', 'arcanetrickster', 'aberrantmind'].includes(subclass.toLowerCase());
+      return subclass && ['eldritchknight', 'arcanetrickster', 'aberrantmind', 'trickster'].includes(subclass.toLowerCase());
     });
     
     const isSpellcaster = hasClassSpellcasting || hasActorSpellcasting || hasKnownSpellcastingClass || hasSubclassSpellcasting || hasSubclassInClassData;

--- a/src/hooks/tests/character-permutation-tests.js
+++ b/src/hooks/tests/character-permutation-tests.js
@@ -102,7 +102,7 @@ export function createCharacterPermutationTestHelpers(context, classConfig = {})
     const normalized = String(identifier || '').toLowerCase();
     if (['bard', 'cleric', 'druid', 'sorcerer', 'wizard'].includes(normalized)) return 'full';
     if (['paladin', 'ranger', 'artificer'].includes(normalized)) return 'half';
-    if (['eldritchknight', 'arcanetrickster'].includes(normalized)) return 'third';
+    if (['eldritchknight', 'arcanetrickster', 'trickster'].includes(normalized)) return 'third';
     if (normalized === 'warlock') return 'pact';
     return 'none';
   };

--- a/src/stores/spellSelection.js
+++ b/src/stores/spellSelection.js
@@ -692,7 +692,7 @@ export const spellLimits = derived(
         
         const isFirstThirdCasterSpellLevel = oldLevel === 2 && $newLevelValueForExistingClass === 3;
         const spellcastingSubclassIdentifier = getSpellcastingSubclassIdentifier($currentCharacter);
-        const isKnownThirdCasterSubclass = ['eldritch-knight', 'eldritchknight', 'arcane-trickster', 'arcanetrickster']
+        const isKnownThirdCasterSubclass = ['eldritch-knight', 'eldritchknight', 'arcane-trickster', 'arcanetrickster', 'trickster']
           .includes(spellcastingSubclassIdentifier);
 
         if (oldSubclassLimits || (isFirstThirdCasterSpellLevel && isKnownThirdCasterSubclass)) {

--- a/src/tests/test-12-debug-spell-condition.test.js
+++ b/src/tests/test-12-debug-spell-condition.test.js
@@ -130,7 +130,7 @@ describe('Debug Shopping Spell Selection Condition', () => {
       if (!isSpellcaster) {
         const knownSpellcastingClasses = [
           'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard',
-          'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight'
+          'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight', 'trickster'
         ];
         const hasKnownSpellcastingClass = classKeys.some(className => knownSpellcastingClasses.includes(className.toLowerCase()));
         console.log('hasKnownSpellcastingClass:', hasKnownSpellcastingClass);

--- a/src/tests/test-eldritch-knight-fix.test.js
+++ b/src/tests/test-eldritch-knight-fix.test.js
@@ -105,7 +105,7 @@ describe('Eldritch Knight Spell Selection Fix', () => {
 
         const knownSpellcastingClasses = [
           'bard', 'cleric', 'druid', 'paladin', 'ranger', 'sorcerer', 'warlock', 'wizard',
-          'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight'
+          'artificer', 'aberrantmind', 'arcanetrickster', 'eldritchknight', 'trickster'
         ];
         const hasKnownSpellcastingClass = classNamesLower.some(className => 
           knownSpellcastingClasses.includes(className)


### PR DESCRIPTION
Hi, big fan of your module!

I can't quite tell when that happened, but for the premium WotC PHB 24 handbook module the arcane trickster subclass returns 'trickster' instead of 'arcanetrickster' or 'arcane-trickster' as the identifier, breaking the selection of spells for that subclass. 

My setup:

Foundry: Version 13 Stable - Build 351
D&D 5 Game System: Version 5.3.3
PHB 24 Module: Version 2.1.0
Actor Studio Module: Version 2.9.11

The issue is reproducable for me with all other modules disabled.

I'm not well versed in javascript or the development of foundry modules, but this fix seemed to do the trick for me.