### PR TITLE
Add plus/minus quantity controls to shop basket

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -609,6 +609,7 @@
       "Roll": "Roll",
       "Increase": "Increase",
       "Decrease": "Decrease",
+      "Remove": "Remove",
       "Subclass": "Subclass"
     },
     "Spells": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -609,6 +609,7 @@
       "Roll": "ロール",
       "Increase": "増加",
       "Decrease": "減少",
+      "Remove": "削除",
       "Subclass": "サブクラス"
     },
     "Spells": {

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -609,6 +609,7 @@
       "Roll": "擲骰",
       "Increase": "增加",
       "Decrease": "減少",
+      "Remove": "移除",
       "Subclass": "子職"
     },
     "Spells": {

--- a/src/components/organisms/dnd5e/Tabs/ShopTab.svelte
+++ b/src/components/organisms/dnd5e/Tabs/ShopTab.svelte
@@ -117,12 +117,27 @@
       const cart = get(shopCart);
       if (!cart.has(itemId)) return;
 
-      const { itemData } = cart.get(itemId);
+      const { itemData, uuid } = cart.get(itemId);
       const quantity = Math.max(0, newQuantity);
       
-      updateCart(itemId, quantity, itemData);
+      updateCart(itemId, quantity, itemData, uuid);
     } catch(error) {
       console.error("Error updating item quantity:", error);
+      ui.notifications?.warn(t('Shop.ErrorUpdateQuantity'));
+    }
+  }
+
+  // Change by one item bundle, matching the increment used by the shop list.
+  function changeItemQuantity(itemId, direction) {
+    try {
+      const cart = get(shopCart);
+      const cartItem = cart.get(itemId);
+      if (!cartItem) return;
+
+      const quantityStep = Number(cartItem.itemData?.system?.quantity) || 1;
+      updateItemQuantity(itemId, cartItem.quantity + (direction * quantityStep));
+    } catch(error) {
+      console.error("Error changing item quantity:", error);
       ui.notifications?.warn(t('Shop.ErrorUpdateQuantity'));
     }
   }
@@ -251,7 +266,37 @@
               </div>
             </div>
             <div class="cart-item-col3">
-              <button class="remove-btn" on:click={() => removeFromCart(cartItem.id)} disabled={isDisabled}>
+              <div class="quantity-controls">
+                <button
+                  type="button"
+                  class="quantity-btn"
+                  on:click|preventDefault={() => changeItemQuantity(cartItem.id, -1)}
+                  disabled={isDisabled}
+                  aria-label={`${t('AltText.Decrease')} ${cartItem.item.name}`}
+                  title={`${t('AltText.Decrease')} ${cartItem.item.name}`}
+                >
+                  <i class="fas fa-minus" aria-hidden="true"></i>
+                </button>
+                <span class="quantity-display">×{cartItem.quantity}</span>
+                <button
+                  type="button"
+                  class="quantity-btn"
+                  on:click|preventDefault={() => changeItemQuantity(cartItem.id, 1)}
+                  disabled={isDisabled}
+                  aria-label={`${t('AltText.Increase')} ${cartItem.item.name}`}
+                  title={`${t('AltText.Increase')} ${cartItem.item.name}`}
+                >
+                  <i class="fas fa-plus" aria-hidden="true"></i>
+                </button>
+              </div>
+              <button
+                type="button"
+                class="remove-btn"
+                on:click|preventDefault={() => removeFromCart(cartItem.id)}
+                disabled={isDisabled}
+                aria-label={`${t('AltText.Remove')} ${cartItem.item.name}`}
+                title={`${t('AltText.Remove')} ${cartItem.item.name}`}
+              >
                 <i class="fas fa-trash"></i>
               </button>
             </div>
@@ -455,8 +500,33 @@
       flex-shrink: 0
       display: flex
       align-items: center
+      gap: 0.25rem
       padding-top: 0.5rem
       padding-bottom: 0.5rem
+
+    .quantity-controls
+      display: flex
+      align-items: center
+      gap: 0.15rem
+
+    .quantity-btn
+      background: none
+      border: 1px solid var(--color-border-light-tertiary)
+      border-radius: 3px
+      cursor: pointer
+      min-width: 1.5rem
+      min-height: 1.5rem
+      padding: 0.1rem
+      line-height: 1
+
+      &:hover
+        background: rgba(0, 0, 0, 0.1)
+
+      &:disabled
+        opacity: 0.5
+        cursor: not-allowed
+        &:hover
+          background: none
 
     .remove-btn
       background: none


### PR DESCRIPTION
## Summary

Implements the quantity controls requested in #175.

- Adds accessible plus and minus buttons to each shop basket row.
- Changes quantities by the item bundle size used by the existing shop-list add button.
- Removes the basket row when decrementing reaches zero.
- Preserves the stored item UUID when changing quantities so container handling still works.
- Adds localized remove labels for English, Japanese, and Traditional Chinese.

## Validation

- `bun run test -- --run` — 96 files, 780 tests passed.
- `bun run build` — passed; generated output was not included in the PR.
- ESLint could not run because this checkout has only the legacy `.eslintrc` while the installed ESLint is v9.

Fixes #175
